### PR TITLE
fix: use only allowed characters for AD password

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -110,8 +110,10 @@ resource "azurerm_role_assignment" "grant_reader_role_to_subscriptions" {
 }
 
 resource "random_password" "generator" {
-  count  = var.create ? 1 : 0
-  length = var.password_length
+  count            = var.create ? 1 : 0
+  length           = var.password_length
+  special          = true
+  override_special = "!@#$%&*()-_=+[]{}:;,.~?^"
 }
 
 resource "azuread_application_password" "client_secret" {


### PR DESCRIPTION
Following this documentation:

https://docs.microsoft.com/en-us/azure/active-directory/authentication/concept-sspr-policy#password-policies-that-only-apply-to-cloud-user-accounts

We are restricting the password to only allowed characters.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>