### PR TITLE
ci: switch releases to be own by Lacework releng ⚡

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - checkout
       - add_ssh_keys:
           fingerprints:
-            - "84:09:be:d5:32:19:78:a4:82:f8:e9:2f:69:75:8e:4f"
+            - "dd:a1:b0:4d:99:de:4f:ce:dc:09:2a:40:6f:92:06:5d"
       - run: scripts/release.sh trigger
   release:
     executor: alpine

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -10,8 +10,8 @@ set -eou pipefail
 
 readonly org_name=lacework
 readonly project_name=terraform-azure-ad-application
-readonly git_user="Salim Afiune Maya"
-readonly git_email="afiune@lacework.net"
+readonly git_user="Lacework Inc."
+readonly git_email="ops+releng@lacework.net"
 VERSION=$(cat VERSION)
 
 usage() {


### PR DESCRIPTION
As a Lacework Engineer, 
I would like to use an in-house Github account to set up all releases and pipelines
So I don't have to use my personal Github account.

## Description
We are starting to use the company's Github account https://github.com/lacework-releng to do
our automated releases.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>