### PR TITLE
fix: updating to proper `azuread` provider version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.31"
 
   required_providers {
-    azuread = ">= 0.11"
+    azuread = "~> 1.2"
     azurerm = "~> 2.26"
   }
 }


### PR DESCRIPTION
The `display_name` variable was introduced in v1.2 and `name` will be removed in v2.0 of the `azuread` provider.

https://github.com/hashicorp/terraform-provider-azuread/releases/tag/v1.2.0