### PR TITLE
feat: add variable to override Active Directory Application owners

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ data "azuread_client_config" "current" {}
 resource "azuread_application" "lacework" {
   count         = var.create ? 1 : 0
   display_name  = var.application_name
-  owners        = [data.azuread_client_config.current.object_id]
+  owners        = length(var.application_owners) == 0 ? [data.azuread_client_config.current.object_id] : var.application_owners
   logo_image    = filebase64("${path.module}/imgs/lacework_logo.png")
   marketing_url = "https://www.lacework.com/"
   web {

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,12 @@ variable "application_identifier_uris" {
   default     = []
 }
 
+variable "application_owners" {
+  type = list(string)
+  default = []
+  description = "The owners of the Azure Active Directory Application. If empty, current user will be owner"
+}
+
 variable "subscription_ids" {
   type        = list(string)
   description = "[DEPRECATED] List of subscriptions to grant read access to. By default the module will only use the primary subscription"


### PR DESCRIPTION
---
Add variable to override Active Directory Application owners
---

***Description:***
When run by different users, Terraform will change the owner of the Azure Application to the current user's id.
I've added a variable that allows to override the default value ( `[data.azuread_client_config.current.object_id]`) with our own set of ids, thus solving the problem.
Note that if the variable is not defined, it behaves like before.


