### PR TITLE
feat: deprecate support for Terraform 0.12 and 0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,29 +6,54 @@
 [![Codefresh build status](https://g.codefresh.io/api/badges/pipeline/lacework/terraform-modules%2Ftest-compatibility?type=cf-1&key=eyJhbGciOiJIUzI1NiJ9.NWVmNTAxOGU4Y2FjOGQzYTkxYjg3ZDEx.RJ3DEzWmBXrJX7m38iExJ_ntGv4_Ip8VTa-an8gBwBo)](https://g.codefresh.io/pipelines/edit/new/builds?id=607e25e6728f5a6fba30431b&pipeline=test-compatibility&projects=terraform-modules&projectId=607db54b728f5a5f8930405d)
 
 Terraform module that creates an Azure Active Directory Application to provide Lacework read-only access to Azure Subscriptions and Tenants.
-Lacework logins to Azure using a service principal (an App Registration) with Directory.Read.All on [MS Graph API](https://docs.microsoft.com/en-us/graph/api/user-list?view=graph-rest-1.0&tabs=http#permissions) which can also be achieved using a [Directory Reader role on Azure AD](https://docs.microsoft.com/en-us/azure/active-directory/roles/permissions-reference#directory-readers) 
+Lacework logins to Azure using a service principal (an App Registration) with Directory.Read.All on [MS Graph API](https://docs.microsoft.com/en-us/graph/api/user-list?view=graph-rest-1.0&tabs=http#permissions) which can also be achieved using a [Directory Reader role on Azure AD](https://docs.microsoft.com/en-us/azure/active-directory/roles/permissions-reference#directory-readers)
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 2.6 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | ~> 2.6 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azuread_application.lacework](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application) | resource |
+| [azuread_application_password.client_secret](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_password) | resource |
+| [azuread_directory_role.dir_reader](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/directory_role) | resource |
+| [azuread_directory_role_member.lacework_dir_reader](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/directory_role_member) | resource |
+| [azuread_service_principal.lacework](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal) | resource |
+| [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs
 
-| Name                        | Description                                                                                                                     | Type           | Default                     | Required |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------              | -------------- | --------------------------- | :------: |
-| application_name            | The name of the Azure Active Directory Application                                                                              | `string`       | `"lacework_security_audit"` | no       |
-| create                      | Set to `false` to prevent the module from creating any resources                                                                | `bool`         | `true`                      | no       |
-| all_subscriptions           | (DEPRECATED) If set to `true`, grant read access to ALL subscriptions within the selected Tenant (overrides `subscription_ids`) | `bool`         | `false`                     | no       |
-| subscription_ids            | (DEPRECATED) List of subscriptions to grant read access to. By default the module will only use the primary subscription        | `list(string)` | `[]`                        | no       |
-| application_identifier_uris | (DEPRECATED) A list of user-defined URI(s) for the Lacework AD Application                                                      | `list(string)` | `[]`                        | no       |
-| key_vault_ids               | (DEPRECATED) A list of Key Vault Ids used in your subscription for the Lacework AD App to have access to                        | `list(string)` | `[]`                        | no       |
-| management_group_id         | (DEPRECATED) The ID of the Management Group                                                                                     | `string`       | `""`                        | no       |
-| password_length             | [DEPRECATED] The length of the Lacework AD Application password                                                                 | `number`       | `30`                        | no       |
-| tenant_id                   | A Tenant ID different from the default defined inside the provider                                                              | `string`       | `""`                        | no       |
-| use_management_group        | (DEPRECATED) If set to `true`, the AD Application will be set up to leverage a Management Group                                 | `bool`         | `false`                     | no       |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_all_subscriptions"></a> [all\_subscriptions](#input\_all\_subscriptions) | [DEPRECATED] Use this input on upstream modules. (<https://registry.terraform.io/modules/lacework/config/azure/latest?tab=inputs> and <https://registry.terraform.io/modules/lacework/activity-log/azure/latest?tab=inputs>) | `bool` | `false` | no |
+| <a name="input_application_identifier_uris"></a> [application\_identifier\_uris](#input\_application\_identifier\_uris) | [DEPRECATED] A list of user-defined URI(s) for the Lacework AD Application | `list(string)` | `[]` | no |
+| <a name="input_application_name"></a> [application\_name](#input\_application\_name) | The name of the Azure Active Directory Application | `string` | `"lacework_security_audit"` | no |
+| <a name="input_application_owners"></a> [application\_owners](#input\_application\_owners) | The owners of the Azure Active Directory Application. If empty, current user will be owner | `list(string)` | `[]` | no |
+| <a name="input_create"></a> [create](#input\_create) | Set to `false` to prevent the module from creating any resources | `bool` | `true` | no |
+| <a name="input_key_vault_ids"></a> [key\_vault\_ids](#input\_key\_vault\_ids) | [DEPRECATED] A list of Key Vault Ids used in your subscription for the Lacework AD App to have access to | `list(string)` | `[]` | no |
+| <a name="input_management_group_id"></a> [management\_group\_id](#input\_management\_group\_id) | [DEPRECATED] Use this input on upstream module: <https://registry.terraform.io/modules/lacework/config/azure/latest?tab=inputs> | `string` | `""` | no |
+| <a name="input_password_length"></a> [password\_length](#input\_password\_length) | [DEPRECATED] The length of the Lacework AD Application password | `number` | `30` | no |
+| <a name="input_subscription_ids"></a> [subscription\_ids](#input\_subscription\_ids) | [DEPRECATED] Use this input on upstream modules. (<https://registry.terraform.io/modules/lacework/config/azure/latest?tab=inputs> and <https://registry.terraform.io/modules/lacework/activity-log/azure/latest?tab=inputs>) | `list(string)` | `[]` | no |
+| <a name="input_tenant_id"></a> [tenant\_id](#input\_tenant\_id) | [DEPRECATED] A Tenant ID different from the default defined inside the provider | `string` | `""` | no |
+| <a name="input_use_management_group"></a> [use\_management\_group](#input\_use\_management\_group) | [DEPRECATED] Use this input on upstream module: <https://registry.terraform.io/modules/lacework/config/azure/latest?tab=inputs> | `bool` | `false` | no |
 
 ## Outputs
 
-| Name                 | Description                                                   |
-| -------------------- | ------------------------------------------------              |
-| application_id       | The Lacework AD Application id                                |
-| application_password | The Lacework AD Application password                          |
-| created              | Was the Active Directory Application created                  |
-| service_principal_id | The Lacework Service Principal id                             |
-| tenant_id            | (DEPRECATED) A Tenant ID used to configure the AD Application |
+| Name | Description |
+|------|-------------|
+| <a name="output_application_id"></a> [application\_id](#output\_application\_id) | The Lacework AD Application id |
+| <a name="output_application_password"></a> [application\_password](#output\_application\_password) | The Lacework AD Application password |
+| <a name="output_created"></a> [created](#output\_created) | Was the Active Directory Application created |
+| <a name="output_service_principal_id"></a> [service\_principal\_id](#output\_service\_principal\_id) | The Lacework Service Principal id |
+| <a name="output_tenant_id"></a> [tenant\_id](#output\_tenant\_id) | [DEPRECATED] A Tenant ID used to configure the AD Application |

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.31"
+  required_version = ">= 0.14"
 
   required_providers {
     azuread = {


### PR DESCRIPTION
Signed-off-by: Darren Murray <darren.murray@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Deprecate support for Terraform 0.12 and 0.13

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

Add Terraform 1.1 to terraform modules compatibility tests

## Issue

https://lacework.atlassian.net/browse/ALLY-954

