### PR TITLE
fix(deps): updating azuread and migrating from deprecated resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Lacework logins to Azure using a service principal (an App Registration) with Di
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 2.6 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 2.25 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | ~> 2.6 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | ~> 2.25 |
 
 ## Resources
 
@@ -28,7 +28,7 @@ Lacework logins to Azure using a service principal (an App Registration) with Di
 | [azuread_application.lacework](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application) | resource |
 | [azuread_application_password.client_secret](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_password) | resource |
 | [azuread_directory_role.dir_reader](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/directory_role) | resource |
-| [azuread_directory_role_member.lacework_dir_reader](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/directory_role_member) | resource |
+| [azuread_directory_role_assignment.lacework_dir_reader](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/directory_role_assignment) | resource |
 | [azuread_service_principal.lacework](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal) | resource |
 | [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/client_config) | data source |
 

--- a/examples/default-ad-application/README.md
+++ b/examples/default-ad-application/README.md
@@ -9,7 +9,7 @@ provider "azuread" {}
 
 module "ad_application" {
   source  = "lacework/ad-application/azure"
-  version = "~> 0.1"
+  version = "~> 1.0"
 }
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -43,10 +43,10 @@ resource "azuread_application_password" "client_secret" {
 # When to use this role? When Granting service principals access to directory where
 # Directory.Read.All is not an option. This way we avoid Grant Admin Consent issue.
 #
-# => https://docs.microsoft.com/en-us/azure/active-directory/roles/permissions-reference#directory-readers 
-resource "azuread_directory_role_member" "lacework_dir_reader" {
-  count            = var.create ? 1 : 0
-  role_object_id   = azuread_directory_role.dir_reader.object_id
-  member_object_id = local.service_principal_id
-  depends_on       = [azuread_service_principal.lacework]
+# => https://docs.microsoft.com/en-us/azure/active-directory/roles/permissions-reference#directory-readers
+resource "azuread_directory_role_assignment" "lacework_dir_reader" {
+  count               = var.create ? 1 : 0
+  role_id             = azuread_directory_role.dir_reader.template_id
+  principal_object_id = local.service_principal_id
+  depends_on          = [azuread_service_principal.lacework]
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.6"
+      version = "~> 2.25"
     }
   }
 }


### PR DESCRIPTION
***Issue***: the AzureAD provider has deprecated the `azuread_directory_role_member` resource with version 2.25.0, stating that it will be removed in AzureAD 3.0

```
╷
│ Warning: Deprecated Resource
│ 
│   with module.azure_activity_log.module.az_ad_application.azuread_directory_role_member.lacework_dir_reader,
│   on .terraform/modules/azure_activity_log.az_ad_application/main.tf line 47, in resource "azuread_directory_role_member" "lacework_dir_reader":
│   47: resource "azuread_directory_role_member" "lacework_dir_reader" {
│ 
│ This resource is deprecated and will be removed in version 3.0 of the AzureAD provider. Please use the `azuread_directory_role_assignment` resource instead.
```

***Description:***
This PR updates from the `azuread_directory_role_member` resource to the new `azuread_directory_role_assignment` resource.

***Additional Info:***
Version 2.25.0 of the AzureAD provider just released a few days ago, so it's very possible we'll want to wait some time - or even until 3.0 is released.  The `azuread_directory_role_assignment` resource is newly added in 2.25.0.

