### PR TITLE
update output with enable_directory_reader

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -3,6 +3,11 @@ output "created" {
   description = "Was the Active Directory Application created"
 }
 
+output "enable_directory_reader" {
+  value       = var.enable_directory_reader
+  description = "Was the Active Directory Application granted Directory Reader role in Azure AD?"
+}
+
 output "application_password" {
   value       = local.application_password
   description = "The Lacework AD Application password"


### PR DESCRIPTION
feat(config): Flag enable_directory_reader
This change allows a setting to enable or disable granting Directory  Reader to the AD app registration, and to see its output variable
Fixes the use-case for GDPR customers not wanting us to read from the directory

---
name: Enable enable_directory_reader output
about: 'feat(config): Flag enable_directory_reader'
---

Issue: RAIN-35343

Description:
So customers can choose not to collect their Azure AD information (opt-out) , for compliance reasons
