### PR TITLE
feat: Set owner for service principal

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,7 @@ resource "azuread_directory_role" "dir_reader" {
 resource "azuread_service_principal" "lacework" {
   count          = var.create ? 1 : 0
   application_id = local.application_id
+  owners        = length(var.application_owners) == 0 ? [data.azuread_client_config.current.object_id] : var.application_owners
 }
 
 resource "azuread_application_password" "client_secret" {


### PR DESCRIPTION
***Description:***
This adds setting the owner for the service principal. Currently the owner is only set for the application. Without this when the service principal is created, it's possible for Terraform to lose access to the Service Principal once it's created.

